### PR TITLE
Update schema, change sync logic to add values from parent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,6 @@ jobs:
                      --password=$SANDBOX_PASSWORD \
                      --client-id=50 \
                      tests
-      - slack/notify-on-failure:
-          only_for_branches: master
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,56 @@
+version: 2.1
+orbs:
+  slack: circleci/slack@3.4.2
+
+jobs:
+  build:
+    docker:
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+    steps:
+      - checkout
+      - run:
+          name: 'Setup virtual env'
+          command: |
+            python3 -mvenv /usr/local/share/virtualenvs/tap-yotpo
+            source /usr/local/share/virtualenvs/tap-yotpo/bin/activate
+            pip install -U 'pip<19.2' 'setuptools<51.0.0'
+            pip install .[dev]
+      - run:
+          name: 'pylint'
+          command: |
+            source /usr/local/share/virtualenvs/tap-yotpo/bin/activate
+            pylint tap_yotpo -d C,R,W
+      - add_ssh_keys
+      - run:
+          name: 'Integration Tests'
+          command: |
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            run-test --tap=tap-yotpo \
+                     --target=target-stitch \
+                     --orchestrator=stitch-orchestrator \
+                     --email=harrison+sandboxtest@stitchdata.com \
+                     --password=$SANDBOX_PASSWORD \
+                     --client-id=50 \
+                     tests
+      - slack/notify-on-failure:
+          only_for_branches: master
+
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build:
+          context: circleci-user
+  build_daily:
+    triggers:
+      - schedule:
+          cron: "0 19 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build:
+          context: circleci-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,4 @@
 version: 2.1
-orbs:
-  slack: circleci/slack@3.4.2
-
 jobs:
   build:
     docker:

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,12 @@ setup(
         "requests==2.20.0",
         "pendulum==1.2.0",
     ],
+    extras_require={
+        'dev': [
+            'pylint',
+            'ipdb',
+        ]
+    },
     entry_points="""
     [console_scripts]
     tap-yotpo=tap_yotpo:main

--- a/tap_yotpo/context.py
+++ b/tap_yotpo/context.py
@@ -3,7 +3,7 @@ from singer import bookmarks as bks_
 from .http import Client
 
 
-class Context(object):
+class Context():
     """Represents a collection of global objects necessary for performing
     discovery or for running syncs. Notably, it contains
 
@@ -30,10 +30,9 @@ class Context(object):
     @catalog.setter
     def catalog(self, catalog):
         self._catalog = catalog
-        self.selected_stream_ids = set(
-            [s.tap_stream_id for s in catalog.streams
-             if s.is_selected()]
-        )
+        self.selected_stream_ids = {s.tap_stream_id
+                                    for s in catalog.streams
+                                    if s.is_selected()}
 
     def get_bookmark(self, path):
         return bks_.get_bookmark(self.state, *path)

--- a/tap_yotpo/schemas/product_reviews.json
+++ b/tap_yotpo/schemas/product_reviews.json
@@ -6,6 +6,12 @@
     "id": {
       "type": "integer"
     },
+    "domain_key": {
+      "type": ["string", "null"]
+    },
+    "name": {
+      "type": ["string", "null"]
+    },
     "created_at": {
       "type": "string",
       "format": "date-time"

--- a/tap_yotpo/streams.py
+++ b/tap_yotpo/streams.py
@@ -11,7 +11,7 @@ EMAILS_LOOKBACK_DAYS = 30
 REVIEWS_LOOKBACK_DAYS = 30
 
 
-class Stream(object):
+class Stream():
     def __init__(self, tap_stream_id, pk_fields, path,
                  returns_collection=True,
                  collection_key=None,

--- a/tap_yotpo/streams.py
+++ b/tap_yotpo/streams.py
@@ -16,7 +16,6 @@ class Stream(object):
                  returns_collection=True,
                  collection_key=None,
                  pluck_results=False,
-                 custom_formatter=None,
                  version=None):
         self.tap_stream_id = tap_stream_id
         self.pk_fields = pk_fields
@@ -24,7 +23,6 @@ class Stream(object):
         self.returns_collection = returns_collection
         self.collection_key = collection_key
         self.pluck_results = pluck_results
-        self.custom_formatter = custom_formatter or (lambda x: x)
         self.version = version
 
         self.start_date = None
@@ -53,7 +51,7 @@ class Stream(object):
                 records = response or []
         else:
             records = [] if not response else [response]
-        return self.custom_formatter(records)
+        return records
 
 
 class Paginated(Stream):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,89 @@
+import os
+import tap_tester.connections as connections
+import tap_tester.menagerie   as menagerie
+import tap_tester.runner      as runner
+from functools import reduce
+import unittest
+
+class Yotpo(unittest.TestCase):
+    def name(self):
+        return "tap_tester_yotpo"
+
+    def setUp(self):
+        missing_envs = [x for x in [os.getenv('TAP_YOTPO_API_KEY'),
+                                    os.getenv('TAP_YOTPO_API_SECRET')] if x == None]
+        if len(missing_envs) != 0:
+            raise Exception("set TAP_YOTPO_API_KEY, TAP_YOTPO_API_SECRET")
+
+    def get_type(self):
+        return "platform.yotpo"
+
+    @staticmethod
+    def tap_name():
+        return "yotpo"
+
+    def expected_check_streams(self):
+        return {
+            'products',
+            'reviews'
+        }
+
+    def expected_sync_streams(self):
+        return {
+            'products',
+            'reviews'
+        }
+
+    def expected_pks(self):
+        return {
+            'products': {"id"},
+            'reviews': {"id"}
+        }
+
+    def get_credentials(self):
+        return {'api_key': os.getenv('TAP_YOTPO_API_KEY'),
+                'api_secret': os.getenv('TAP_YOTPO_API_SECRET')
+        }
+
+    def get_properties(self):
+        return {
+            'start_date' : '2017-01-01T00:00:00Z'
+        }
+
+    def test_run(self):
+        conn_id = connections.ensure_connection(self)
+
+        # Run the tap in check mode
+        check_job_name = runner.run_check_mode(self, conn_id)
+
+        # Verify the check's exit status
+        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
+        menagerie.verify_check_exit_status(self, exit_status, check_job_name)
+
+        # Verify that there are catalogs found
+        found_catalogs = menagerie.get_catalogs(conn_id)
+        self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
+
+        found_catalog_names = set(map(lambda c: c['tap_stream_id'], found_catalogs))
+        subset = self.expected_check_streams().issubset( found_catalog_names )
+        self.assertTrue(subset, msg="Expected check streams are not subset of discovered catalog")
+
+        # Select some catalogs
+        our_catalogs = [c for c in found_catalogs if c.get('tap_stream_id') in self.expected_sync_streams()]
+        for catalog in our_catalogs:
+            schema = menagerie.get_annotated_schema(conn_id, catalog['stream_id'])
+            connections.select_catalog_and_fields_via_metadata(conn_id, catalog, schema)
+
+        # Clear State and run sync
+        menagerie.set_state(conn_id, {})
+        sync_job_name = runner.run_sync_mode(self, conn_id)
+
+        # Verify tap and target exit codes
+        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
+        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+
+        # Verify rows were synced
+        record_count_by_stream = runner.examine_target_output_file(self, conn_id, self.expected_sync_streams(), self.expected_pks())
+        replicated_row_count =  reduce(lambda accum,c : accum + c, record_count_by_stream.values())
+        self.assertGreater(replicated_row_count, 0, msg="failed to replicate any data: {}".format(record_count_by_stream))
+        print("total replicated row count: {}".format(replicated_row_count))


### PR DESCRIPTION
# Description of change
The response from the `product_reviews` endpoint has the following shape:
```
{
  "response": {
    "products": [{}],
    "reviews": [{}, {}, {}, ...]
  }
}
```

This PR adds two fields to the `product_reviews` stream, `domain_key` and `name`, by fetching the fields off of the one object in the `products` array.

# Manual QA steps
- Ran the tap against a test account 
- Found that `products` is either empty or of length 1
- Found that the `products` object always has the two fields we are adding

# Risks
- We are making the assumption that `response['response']['products']` has only one object in that array. If this is untrue, we would see a data discrepancy because we would force every review to relate the the first object's `domain_key` and `name`.
- If this  `products` array is empty, the tap should still work.

# Rollback steps
 - revert this branch
