### PR TITLE
TLD-13498: Updated execption handling for status code 404

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,11 @@ jobs:
             pylint tap_yotpo -d C,R,W
       - add_ssh_keys
       - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-yotpo/bin/activate
+            nosetests tests/unittests/
+      - run:
           name: 'Integration Tests'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-yotpo/bin/activate
+            pip install nose
             nosetests tests/unittests/
       - run:
           name: 'Integration Tests'

--- a/tap_yotpo/http.py
+++ b/tap_yotpo/http.py
@@ -15,6 +15,8 @@ GRANT_TYPE = "client_credentials"
 class RateLimitException(Exception):
     pass
 
+class NotFoundException(Exception):
+    pass
 
 def _join(a, b):
     return a.rstrip("/") + "/" + b.lstrip("/")
@@ -66,7 +68,7 @@ class Client(object):
         if response.status_code in [429, 503, 504]:
             raise RateLimitException()
         if response.status_code == 404:
-            return None
+            raise NotFoundException()
         response.raise_for_status()
         return response.json()
 

--- a/tests/unittests/test_error_handling.py
+++ b/tests/unittests/test_error_handling.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest import mock
+from tap_yotpo import http
+
+# mock responce
+class Mockresponse:
+        def __init__(self, resp, status_code, content=[], headers=None, raise_error=False):
+            self.json_data = resp
+            self.status_code = status_code
+            self.content = content
+            self.headers = headers
+            self.raise_error = raise_error
+
+        def prepare(self):
+            return (self.json_data, self.status_code, self.content, self.headers, self.raise_error)
+
+class TestYotpoErrorHandling(unittest.TestCase):
+
+    def mock_prepare_and_send(request):
+        return Mockresponse("",404)
+
+    @mock.patch("tap_yotpo.http.Client.prepare_and_send",side_effect=mock_prepare_and_send)
+    def test_request_with_handling_for_404_exceptin_handling(self,mock_prepare_and_send):
+        try:
+            request = None
+            tap_stream_id = "tap_yopto"
+            mock_config = {"api_key":"mock_key","api_secret":"mock_secret"}
+            mock_client = http.Client(mock_config)
+            mock_client.request_with_handling(request,tap_stream_id)
+        except http.NotFoundException:
+            pass


### PR DESCRIPTION
# Description of change
- Raised proper exception for status_code 404 of the HTTP response and added unittests for the same.

# Manual QA steps
 - Raising proper exceptions for the wrong URL.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
