### PR TITLE
TDL-5911: Upgreaded Exception Handling and added retry for status cod…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,12 @@ jobs:
             pylint tap_yotpo -d C,R,W
       - add_ssh_keys
       - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-yotpo/bin/activate
+            pip install nose
+            nosetests tests/unittests/
+      - run:
           name: 'Integration Tests'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh

--- a/tap_yotpo/http.py
+++ b/tap_yotpo/http.py
@@ -11,9 +11,74 @@ BASE_URL_V1 = "https://api.yotpo.com/v1"
 
 GRANT_TYPE = "client_credentials"
 
+class YotpoError(Exception):
+    def __init__(self, message=None, response=None):
+        super().__init__(message)
+        self.message = message
+        self.response = response
 
-class RateLimitException(Exception):
+class YotpoBadRequestError(YotpoError):
     pass
+
+class YotpoRateLimitError(YotpoError):
+    pass
+
+class YotpoUnauthorizedError(YotpoError):
+    pass
+
+class YotpoForbiddenError(YotpoError):
+    pass
+
+class YotpoBadGateway(YotpoError):
+    pass
+
+class YotpoNotFoundError(YotpoError):
+    pass
+
+class YotpoTooManyError(YotpoRateLimitError):
+    pass
+
+class YotpoNotAvailableError(YotpoRateLimitError):
+    pass
+
+class YotpoGatewayTimeout(YotpoRateLimitError):
+    pass
+
+
+ERROR_CODE_EXCEPTION_MAPPING = {
+    400: {
+        "raise_exception": YotpoBadRequestError,
+        "message": "A validation exception has occurred."
+    },
+    401: {
+        "raise_exception": YotpoUnauthorizedError,
+        "message": "Invalid authorization credentials."
+    },
+    403: {
+        "raise_exception": YotpoForbiddenError,
+        "message": "User doesn't have permission to access the resource."
+    },
+    404: {
+        "raise_exception": YotpoNotFoundError,
+        "message": "The resource you have specified cannot be found."
+    },
+    429: {
+        "raise_exception": YotpoTooManyError,
+        "message": "The API rate limit for your organisation/application pairing has been exceeded."
+    },
+    502: {
+        "raise_exception": YotpoBadGateway,
+        "message": "Server received an invalid response."
+    },
+    503: {
+        "raise_exception": YotpoNotAvailableError,
+        "message": "API service is currently unavailable."
+    },
+    504: {
+        "raise_exception": YotpoGatewayTimeout,
+        "message": "API service time out, please check Yotpo server."
+    }
+}
 
 
 def _join(a, b):
@@ -56,18 +121,14 @@ class Client(object):
                                 **kwargs)
 
     @backoff.on_exception(backoff.expo,
-                          RateLimitException,
-                          max_tries=10,
+                          (YotpoRateLimitError,YotpoBadRequestError,YotpoBadGateway),
+                          max_tries=3,
                           factor=2)
     def request_with_handling(self, request, tap_stream_id):
         with metrics.http_request_timer(tap_stream_id) as timer:
             response = self.prepare_and_send(request)
             timer.tags[metrics.Tag.http_status_code] = response.status_code
-        if response.status_code in [429, 503, 504]:
-            raise RateLimitException()
-        if response.status_code == 404:
-            return None
-        response.raise_for_status()
+        self.raise_for_error(response)
         return response.json()
 
     def authenticate(self):
@@ -86,3 +147,30 @@ class Client(object):
     def GET(self, version, request_kwargs, *args, **kwargs):
         req = self.create_get_request(version, **request_kwargs)
         return self.request_with_handling(req, *args, **kwargs)
+
+    def raise_for_error(self,resp):
+        try:
+            resp.raise_for_status()
+        except (requests.HTTPError, requests.ConnectionError) as error:
+            try:
+                error_code = resp.status_code
+                # Forming a response message for raising custom exception
+                try:
+                    response_json = resp.json()
+                except Exception:
+                    response_json = {}
+
+                message = "HTTP-error-code: {}, Error: {}".format(
+                    error_code,
+                    response_json.get(
+                        "error", response_json.get(
+                            "Title", response_json.get(
+                                "Detail", ERROR_CODE_EXCEPTION_MAPPING.get(
+                                    error_code, {}).get("message", "Unknown Error")
+                                ))))
+
+                exc = ERROR_CODE_EXCEPTION_MAPPING.get(error_code, {}).get("raise_exception", YotpoError)
+                raise exc(message, resp) from None
+
+            except (ValueError, TypeError):
+                raise YotpoError(error) from None

--- a/tests/unittests/test_error_handling.py
+++ b/tests/unittests/test_error_handling.py
@@ -1,0 +1,163 @@
+import unittest
+from unittest import mock
+import requests
+from tap_yotpo import http
+
+# mock responce
+class Mockresponse:
+        def __init__(self, resp, status_code, content=[], headers=None, raise_error=False):
+            self.json_data = resp
+            self.status_code = status_code
+            self.content = content
+            self.headers = headers
+            self.raise_error = raise_error
+
+        def prepare(self):
+            return (self.json_data, self.status_code, self.content, self.headers, self.raise_error)
+
+        def raise_for_status(self):
+            if not self.raise_error:
+                return self.status_code
+
+            raise requests.HTTPError("mock sample message")
+
+        def json(self):
+            return self.text
+
+class TestYotpoErrorHandling(unittest.TestCase):
+
+    def mock_prepare_and_send_400(request):
+        return Mockresponse("",400,raise_error=True)
+
+    def mock_prepare_and_send_401(request):
+        return Mockresponse("",401,raise_error=True)
+
+    def mock_prepare_and_send_403(request):
+        return Mockresponse("",403,raise_error=True)
+
+    def mock_prepare_and_send_404(request):
+        return Mockresponse("",404,raise_error=True)
+
+    def mock_prepare_and_send_429(request):
+        return Mockresponse("",429,raise_error=True)
+
+    def mock_prepare_and_send_502(request):
+        return Mockresponse("",502,raise_error=True)
+
+    def mock_prepare_and_send_503(request):
+        return Mockresponse("",503,raise_error=True)
+
+    def mock_prepare_and_send_504(request):
+        return Mockresponse("",504,raise_error=True)
+
+    @mock.patch("tap_yotpo.http.Client.prepare_and_send",side_effect=mock_prepare_and_send_400)
+    def test_request_with_handling_for_400_exceptin_handling(self,mock_prepare_and_send):
+        try:
+            request = None
+            tap_stream_id = "tap_yopto"
+            mock_config = {"api_key":"mock_key","api_secret":"mock_secret"}
+            mock_client = http.Client(mock_config)
+            mock_client.request_with_handling(request,tap_stream_id)
+        except http.YotpoBadRequestError as e:
+            expected_error_message = "HTTP-error-code: 400, Error: A validation exception has occurred."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            self.assertEquals(mock_prepare_and_send.call_count,3)
+
+    @mock.patch("tap_yotpo.http.Client.prepare_and_send",side_effect=mock_prepare_and_send_401)
+    def test_request_with_handling_for_401_exceptin_handling(self,mock_prepare_and_send):
+        try:
+            request = None
+            tap_stream_id = "tap_yopto"
+            mock_config = {"api_key":"mock_key","api_secret":"mock_secret"}
+            mock_client = http.Client(mock_config)
+            mock_client.request_with_handling(request,tap_stream_id)
+        except http.YotpoUnauthorizedError as e:
+            expected_error_message = "HTTP-error-code: 401, Error: Invalid authorization credentials."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            self.assertEquals(mock_prepare_and_send.call_count,1)
+    
+    @mock.patch("tap_yotpo.http.Client.prepare_and_send",side_effect=mock_prepare_and_send_403)
+    def test_request_with_handling_for_403_exceptin_handling(self,mock_prepare_and_send):
+        try:
+            request = None
+            tap_stream_id = "tap_yopto"
+            mock_config = {"api_key":"mock_key","api_secret":"mock_secret"}
+            mock_client = http.Client(mock_config)
+            mock_client.request_with_handling(request,tap_stream_id)
+        except http.YotpoForbiddenError as e:
+            expected_error_message = "HTTP-error-code: 403, Error: User doesn't have permission to access the resource."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            self.assertEquals(mock_prepare_and_send.call_count,1)
+
+    @mock.patch("tap_yotpo.http.Client.prepare_and_send",side_effect=mock_prepare_and_send_404)
+    def test_request_with_handling_for_404_exceptin_handling(self,mock_prepare_and_send):
+        try:
+            request = None
+            tap_stream_id = "tap_yopto"
+            mock_config = {"api_key":"mock_key","api_secret":"mock_secret"}
+            mock_client = http.Client(mock_config)
+            mock_client.request_with_handling(request,tap_stream_id)
+        except http.YotpoNotFoundError as e:
+            expected_error_message = "HTTP-error-code: 404, Error: The resource you have specified cannot be found."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            self.assertEquals(mock_prepare_and_send.call_count,1)
+
+    @mock.patch("tap_yotpo.http.Client.prepare_and_send",side_effect=mock_prepare_and_send_429)
+    def test_request_with_handling_for_429_exceptin_handling(self,mock_prepare_and_send):
+        try:
+            request = None
+            tap_stream_id = "tap_yopto"
+            mock_config = {"api_key":"mock_key","api_secret":"mock_secret"}
+            mock_client = http.Client(mock_config)
+            mock_client.request_with_handling(request,tap_stream_id)
+        except http.YotpoTooManyError as e:
+            expected_error_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            self.assertEquals(mock_prepare_and_send.call_count,3)
+
+    @mock.patch("tap_yotpo.http.Client.prepare_and_send",side_effect=mock_prepare_and_send_502)
+    def test_request_with_handling_for_502_exceptin_handling(self,mock_prepare_and_send):
+        try:
+            request = None
+            tap_stream_id = "tap_yopto"
+            mock_config = {"api_key":"mock_key","api_secret":"mock_secret"}
+            mock_client = http.Client(mock_config)
+            mock_client.request_with_handling(request,tap_stream_id)
+        except http.YotpoBadGateway as e:
+            expected_error_message = "HTTP-error-code: 502, Error: Server received an invalid response."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            self.assertEquals(mock_prepare_and_send.call_count,3)
+
+    @mock.patch("tap_yotpo.http.Client.prepare_and_send",side_effect=mock_prepare_and_send_503)
+    def test_request_with_handling_for_503_exceptin_handling(self,mock_prepare_and_send):
+        try:
+            request = None
+            tap_stream_id = "tap_yopto"
+            mock_config = {"api_key":"mock_key","api_secret":"mock_secret"}
+            mock_client = http.Client(mock_config)
+            mock_client.request_with_handling(request,tap_stream_id)
+        except http.YotpoNotAvailableError as e:
+            expected_error_message = "HTTP-error-code: 503, Error: API service is currently unavailable."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            self.assertEquals(mock_prepare_and_send.call_count,3)
+
+    @mock.patch("tap_yotpo.http.Client.prepare_and_send",side_effect=mock_prepare_and_send_504)
+    def test_request_with_handling_for_504_exceptin_handling(self,mock_prepare_and_send):
+        try:
+            request = None
+            tap_stream_id = "tap_yopto"
+            mock_config = {"api_key":"mock_key","api_secret":"mock_secret"}
+            mock_client = http.Client(mock_config)
+            mock_client.request_with_handling(request,tap_stream_id)
+        except http.YotpoGatewayTimeout as e:
+            expected_error_message = "HTTP-error-code: 504, Error: API service time out, please check Yotpo server."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            self.assertEquals(mock_prepare_and_send.call_count,3)


### PR DESCRIPTION
# Description of change
- Updated the Error handling of the HTTP request.
- Added retry for 400 and 502
- Decreased retry from 10 to 3 as 10 is too much. 
- Added Unit test of it.

# Manual QA steps
 - Checked Error message for some of the Errors and messages are proper.
 - 3 times retry is working for 400 and 502
 
# Risks
 - No risk
 
# Rollback steps
 - revert this branch
