### PR TITLE
TDL-13714: Made all fields available except key and replication fields

### DIFF
--- a/tap_yotpo/__init__.py
+++ b/tap_yotpo/__init__.py
@@ -44,7 +44,8 @@ def discover(ctx):
         mdata = metadata.to_map(mdata)
 
         for field_name in schema_dict['properties'].keys():
-            mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
+            mdata = metadata.write(mdata, ('properties', field_name), 'inclusion',
+                                   'automatic' if field_name in stream.pk_fields or field_name in stream.book_mark_keys else 'available')
 
         catalog.streams.append(CatalogEntry(
             stream=stream.tap_stream_id,

--- a/tap_yotpo/__init__.py
+++ b/tap_yotpo/__init__.py
@@ -44,6 +44,7 @@ def discover(ctx):
         mdata = metadata.to_map(mdata)
 
         for field_name in schema_dict['properties'].keys():
+            # Field except primary keys and book mark keys marked as available. 
             mdata = metadata.write(mdata, ('properties', field_name), 'inclusion',
                                    'automatic' if field_name in stream.pk_fields or field_name in stream.book_mark_keys else 'available')
 


### PR DESCRIPTION
# Description of change
- Allow fields to be selected via Metadata
- Only Primary keys and Bookmark keys are automatic, all other keys are available.

# Manual QA steps
 - Ran discover mode and tested the same.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
