### PR TITLE
Version bump to v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 1.3.0
+  * Makes all fields `available` except primary keys and bookmarking keys [#16](https://github.com/singer-io/tap-yotpo/pull/16)
+  * Updates error handling of HTTP request [#13](https://github.com/singer-io/tap-yotpo/pull/13)
+  * Updates `singer-python` and `pendulum` versions [#14](https://github.com/singer-io/tap-yotpo/pull/14)
+  * Fixes transform error on `unsubscribers` stream [#15](https://github.com/singer-io/tap-yotpo/pull/15)
 
 ## 1.2.0
   * Add the `domain_key` and `name` to the `product_reviews` schema

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-yotpo",
-    version="1.2.0",
+    version="1.3.0",
     description="Singer.io tap for extracting data from the Yotpo API",
     author="Stitch",
     url="http://singer.io",


### PR DESCRIPTION
# Description of change
## 1.3.0
  * Makes all fields `available` except primary keys and bookmarking keys [#16](https://github.com/singer-io/tap-yotpo/pull/16)
  * Updates error handling of HTTP request [#13](https://github.com/singer-io/tap-yotpo/pull/13)
  * Updates `singer-python` and `pendulum` versions [#14](https://github.com/singer-io/tap-yotpo/pull/14)
  * Fixes transform error on `unsubscribers` stream [#15](https://github.com/singer-io/tap-yotpo/pull/15)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
