### PR TITLE
TDL-16319 added request timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,9 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-yotpo/bin/activate
-            pip install nose
-            nosetests tests/unittests/
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_yotpo --cover-html-dir=htmlcov tests/unittests
+            coverage html
       - run:
           name: 'Integration Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,10 @@ jobs:
             pip install nose coverage
             nosetests --with-coverage --cover-erase --cover-package=tap_yotpo --cover-html-dir=htmlcov tests/unittests
             coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
       - run:
           name: 'Integration Tests'
           command: |

--- a/README.md
+++ b/README.md
@@ -39,13 +39,15 @@ This tap:
        "api_key": "...",
        "api_secret": "...",
        "email_stats_lookback_days": 30,
-       "reviews_lookback_days": 30
+       "reviews_lookback_days": 30,
+       "request_timeout": 300
    }
    ```
 
    The `start_date` parameter determines the starting date for incremental syncs. The `email_stats_lookback_days` parameter
    is used to fetch updated email statistics (opens, clicks, etc) for emails sent by Yotpo. The `reviews_lookback_days`
    parameter is used to re-fetch reviews that have been updated (or deleted) since the last time they were synced.
+   The `request_timeout` is an optional paramater to set timeout for requests. Default: 300 seconds
 
 4. Run the Tap in Discovery Mode
 

--- a/tap_yotpo/http.py
+++ b/tap_yotpo/http.py
@@ -2,7 +2,7 @@ import requests
 import singer
 from singer import metrics
 import backoff
-from requests import Timeout
+from requests.exceptions import Timeout, ConnectionError
 
 LOGGER = singer.get_logger()
 
@@ -118,8 +118,8 @@ class Client(object):
             raise RuntimeError("Client is not yet authenticated")
         return self._token
 
-    # Backoff for 5 times when a Timeout error occurs when sending the request
-    @backoff.on_exception(backoff.expo, Timeout, max_tries=5, factor=2)
+    # Backoff for 5 times when a Timeout or Connection error occurs when sending the request
+    @backoff.on_exception(backoff.expo, (Timeout, ConnectionError), max_tries=5, factor=2)
     def prepare_and_send(self, request):
         if self.user_agent:
             request.headers["User-Agent"] = self.user_agent

--- a/tap_yotpo/http.py
+++ b/tap_yotpo/http.py
@@ -118,7 +118,7 @@ class Client(object):
             raise RuntimeError("Client is not yet authenticated")
         return self._token
 
-    # backoff for 5 times incase of Timeout
+    # Backoff for 5 times when a Timeout error occurs when sending the request
     @backoff.on_exception(backoff.expo, Timeout, max_tries=5, factor=2)
     def prepare_and_send(self, request):
         if self.user_agent:

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -1,0 +1,102 @@
+from tap_yotpo.http import Client
+import unittest
+from unittest import mock
+from unittest.case import TestCase
+from requests.exceptions import Timeout, ConnectTimeout
+import datetime
+from tap_yotpo import LOGGER
+
+class TestBackoffError(unittest.TestCase):
+    '''
+    Test that backoff logic works properly.
+    '''
+    @mock.patch('tap_yotpo.http.requests.Session.send')
+    @mock.patch('tap_yotpo.http.requests.Session.prepare_request')
+    def test_backoff_prepare_and_send_timeout_error(self, mock_prepare_request, mock_send):
+        """
+        Check whether the request backoffs properly for 5 times in case of Timeout error.
+        """
+        mock_send.side_effect = Timeout
+        with self.assertRaises(Timeout):
+            config = {"start_date": "dummy_st", "api_key": "dummy_key", "api_secret": "dummy_secret"}
+            client = Client(config)
+            client.prepare_and_send("request")
+        self.assertEqual(mock_send.call_count, 5)
+
+class MockResponse():
+    '''
+    Mock response  object for the requests call 
+    '''
+    def __init__(self, resp, status_code, content=[""], headers=None, raise_error=False, text={}):
+        self.json_data = resp
+        self.status_code = status_code
+        self.content = content
+        self.headers = headers
+        self.raise_error = raise_error
+        self.text = text
+        self.reason = "error"
+
+    def prepare(self):
+        return (self.json_data, self.status_code, self.content, self.headers, self.raise_error)
+
+    def json(self):
+        return self.text
+
+class TestRequestTimeoutValue(unittest.TestCase):
+    '''
+    Test that request timeout parameter works properly in various cases
+    '''
+    @mock.patch('tap_yotpo.http.requests.Session.send', return_value = MockResponse("", status_code=200))
+    @mock.patch('tap_yotpo.http.requests.Session.prepare_request', return_value = "request")
+    def test_config_provided_request_timeout(self, mock_request, mock_send):
+        """ 
+            Unit tests to ensure that request timeout is set based on config value
+        """
+        config = {"start_date": "dummy_st", "api_key": "dummy_key", "api_secret": "dummy_secret", "request_timeout": 100}
+        client = Client(config)
+        client.prepare_and_send("request")
+        mock_send.assert_called_with("request", timeout=100.0)
+
+    @mock.patch('tap_yotpo.http.requests.Session.send', return_value = MockResponse("", status_code=200))
+    @mock.patch('tap_yotpo.http.requests.Session.prepare_request', return_value = "request")
+    def test_default_value_request_timeout(self, mock_request, mock_send):
+        """ 
+            Unit tests to ensure that request timeout is set based default value
+        """
+        config = {"start_date": "dummy_st", "api_key": "dummy_key", "api_secret": "dummy_secret"}
+        client = Client(config)
+        client.prepare_and_send("request")
+        mock_send.assert_called_with("request", timeout=300.0)
+
+    @mock.patch('tap_yotpo.http.requests.Session.send', return_value = MockResponse("", status_code=200))
+    @mock.patch('tap_yotpo.http.requests.Session.prepare_request', return_value = "request")
+    def test_config_provided_empty_request_timeout(self, mock_request, mock_send):
+        """ 
+            Unit tests to ensure that request timeout is set based on default value if empty value is given in config
+        """
+        config = {"start_date": "dummy_st", "api_key": "dummy_key", "api_secret": "dummy_secret", "request_timeout": ""}
+        client = Client(config)
+        client.prepare_and_send("request")
+        mock_send.assert_called_with("request", timeout=300.0)
+        
+    @mock.patch('tap_yotpo.http.requests.Session.send', return_value = MockResponse("", status_code=200))
+    @mock.patch('tap_yotpo.http.requests.Session.prepare_request', return_value = "request")
+    def test_config_provided_string_request_timeout(self, mock_request, mock_send):
+        """ 
+            Unit tests to ensure that request timeout is set based on config string value
+        """
+        config = {"start_date": "dummy_st", "api_key": "dummy_key", "api_secret": "dummy_secret", "request_timeout": "100"}
+        client = Client(config)
+        client.prepare_and_send("request")
+        mock_send.assert_called_with("request", timeout=100.0)
+
+    @mock.patch('tap_yotpo.http.requests.Session.send', return_value = MockResponse("", status_code=200))
+    @mock.patch('tap_yotpo.http.requests.Session.prepare_request', return_value = "request")
+    def test_config_provided_float_request_timeout(self, mock_request, mock_send):
+        """ 
+            Unit tests to ensure that request timeout is set based on config float value
+        """
+        config = {"start_date": "dummy_st", "api_key": "dummy_key", "api_secret": "dummy_secret", "request_timeout": 100.8}
+        client = Client(config)
+        client.prepare_and_send("request")
+        mock_send.assert_called_with("request", timeout=100.8)


### PR DESCRIPTION
# Description of change
Added request timeout for API requests with default timeout 300 seconds

# Manual QA steps
 - The request should backoff 5 times in case it is timed out.
- Error should be thrown in case of retries not successful after 5 trials
- Checked the request timeout works for each stream and backoff

 
# Risks
 - 
 
# Rollback steps
 - revert this branch
