### PR TITLE
Bump version 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.3.2
+  * Storefront endpoint URL change [#27](https://github.com/singer-io/tap-yotpo/pull/27)
 ## 1.3.1
   * Request Timeout Implementation
 ## 1.3.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-yotpo",
-    version="1.3.1",
+    version="1.3.2",
     description="Singer.io tap for extracting data from the Yotpo API",
     author="Stitch",
     url="http://singer.io",


### PR DESCRIPTION
# Description of change
This is the Bump version for Storefront URL change for tap-yotpo.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
