### PR TITLE
update products schema

### DIFF
--- a/tap_yotpo/schemas/products.json
+++ b/tap_yotpo/schemas/products.json
@@ -50,10 +50,10 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "number"
+          "type": ["number", "null"]
         },
         "name": {
-          "type": "string"
+          "type": ["string", "null"]
         }
       }
     },


### PR DESCRIPTION
# Description of change

Per Yotpo support RE `/v1/apps/{app_key}/products` endpoint:

> our R&D team recently changed the endpoint and the category parameter are no longer supported/deprecated the reason why it shows as null. However, we cannot delete it as it may cause some backward compatibility issues, especially with the customer who still using it. If you are not using it in some cases, kindly disregard this part of the endpoint. 

I made updates to `category.name` and `category.id` to accept null values

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
