### PR TITLE
add response of unknown errors

### DIFF
--- a/tap_yotpo/http.py
+++ b/tap_yotpo/http.py
@@ -186,11 +186,12 @@ class Client(object):
             message = "HTTP-error-code: {}, Error: {}".format(
                 response.status_code,
                 response_json.get("status", ERROR_CODE_EXCEPTION_MAPPING.get(
-                    response.status_code, {})).get("message", "Unknown Error")
+                    response.status_code, {})).get("message", response.text)
             )
             exc = ERROR_CODE_EXCEPTION_MAPPING.get(
                 response.status_code, {}).get("raise_exception", YotpoError)
-            # Re-authenticating if got an authentication error while collecting stream data and response does not have Bad request (400), Forbidden (403) and Not found (404)
+            # Re-authenticating if got an authentication error while collecting stream data and 
+            # response does not have Bad request (400), Forbidden (403) and Not found (404)
             if not authentication_call and response.status_code not in [400, 403, 404, 429]:
                 self.authenticate()
             raise exc(message, response) from None


### PR DESCRIPTION
# Description of change
Current error logging obscures Yotpo API error responses with "Unknown Error" which makes it difficult to troubleshoot issues. This changes error logging to include unknown error response messages

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
