### PR TITLE
add response of unknown errors (#37)

### DIFF
--- a/tap_yotpo/http.py
+++ b/tap_yotpo/http.py
@@ -186,11 +186,12 @@ class Client(object):
             message = "HTTP-error-code: {}, Error: {}".format(
                 response.status_code,
                 response_json.get("status", ERROR_CODE_EXCEPTION_MAPPING.get(
-                    response.status_code, {})).get("message", "Unknown Error")
+                    response.status_code, {})).get("message", response.text)
             )
             exc = ERROR_CODE_EXCEPTION_MAPPING.get(
                 response.status_code, {}).get("raise_exception", YotpoError)
-            # Re-authenticating if got an authentication error while collecting stream data and response does not have Bad request (400), Forbidden (403) and Not found (404)
+            # Re-authenticating if got an authentication error while collecting stream data and 
+            # response does not have Bad request (400), Forbidden (403) and Not found (404)
             if not authentication_call and response.status_code not in [400, 403, 404, 429]:
                 self.authenticate()
             raise exc(message, response) from None

--- a/tests/unittests/test_error_handling.py
+++ b/tests/unittests/test_error_handling.py
@@ -11,6 +11,7 @@ class Mockresponse:
             self.content = content
             self.headers = headers
             self.raise_error = raise_error
+            self.text = {}
 
         def prepare(self):
             return (self.json_data, self.status_code, self.content, self.headers, self.raise_error)
@@ -224,7 +225,7 @@ class TestYotpoErrorHandling(unittest.TestCase):
             mock_client = http.Client(mock_config)
             mock_client.GET('v1',{"path": "apps/:api_key/products?utoken=:token", "params": {"count": 1,"page": 1}},tap_stream_id)
         except http.YotpoError as e:
-            expected_error_message = "HTTP-error-code: 505, Error: Unknown Error"
+            expected_error_message = "HTTP-error-code: 505, Error: {}"
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
             self.assertEquals(mock_prepare_and_send.call_count,1)


### PR DESCRIPTION
Co-authored-by: Robert Hill <robert@bollandbranch.com>

# Description of change
Current error logging obscures Yotpo API error responses with "Unknown Error" which makes it difficult to troubleshoot issues. This changes error logging to include unknown error response messages
Replica of https://github.com/singer-io/tap-yotpo/pull/36. To run the circleci jobs before merging to master.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
