### PR TITLE
add deleted=true param to reviews request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.1
+  * Fix reviews stream to also sync deleted reviews  [#54](https://github.com/singer-io/tap-yotpo/pull/54)
+
 ## 2.0.0
   * Code refactoring [#46](https://github.com/singer-io/tap-yotpo/pull/46)
     * Add new streams `orders`, `order_fulfillments`, `product_variants` and `collections`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.0.1
-  * Fix reviews stream to also sync deleted reviews  [#54](https://github.com/singer-io/tap-yotpo/pull/54)
+  * Fix reviews stream to also sync deleted reviews  [#55](https://github.com/singer-io/tap-yotpo/pull/55)
 
 ## 2.0.0
   * Code refactoring [#46](https://github.com/singer-io/tap-yotpo/pull/46)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="tap-yotpo",
-    version="2.0.0",
+    version="2.0.1",
     description="Singer.io tap for extracting data from the Yotpo API",
     author="Stitch",
     url="https://singer.io",

--- a/tap_yotpo/streams/reviews.py
+++ b/tap_yotpo/streams/reviews.py
@@ -27,7 +27,7 @@ class Reviews(IncrementalStream, UrlEndpointMixin, PageSizeMixin):
         """performs querying and pagination of reviews resource."""
         # pylint: disable=W0221
         extraction_url = self.get_url_endpoint()
-        params = {"page": 1, "count": self.page_size, "since_updated_at": bookmark_date}
+        params = {"page": 1, "count": self.page_size, "since_updated_at": bookmark_date, "deleted": "true"}
         while True:
             response = self.client.get(extraction_url, params, {}, self.api_auth_version)
             raw_records = response.get(self.stream, [])


### PR DESCRIPTION
# Description of change
`reviews` stream used to request deleted reviews. The v2.0.0 update removed this from the request. 
This change adds the `deleted=true` param back to the reviews request.

# Manual QA steps
 - Verified same records returned on v2 as v1 with param added

# Risks
 - Any syncs that were run with v2 will need to reset to get all deleted reviews

# Rollback steps
 - revert this branch
