### PR TITLE
PR 1 - [SAC-28902] - `parent-tap-stream-id` in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.1.0
   * Add parent-tap-stream-id metadata for child streams [#65](https://github.com/singer-io/tap-yotpo/pull/65)
+  * Bump dependency versions: `singer-python` to `6.8.0`
 
 ## 2.0.5
   * Bump dependency versions for twistlock compliance [#61](https://github.com/singer-io/tap-yotpo/pull/61)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.0
+  * Add parent-tap-stream-id metadata for child streams [#65](https://github.com/singer-io/tap-yotpo/pull/65)
+
 ## 2.0.5
   * Bump dependency versions for twistlock compliance [#61](https://github.com/singer-io/tap-yotpo/pull/61)
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     py_modules=["tap_yotpo"],
     install_requires=[
         "singer-python==6.8.0",
-        "requests==2.34.0",
+        "requests==2.34.2",
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="tap-yotpo",
-    version="2.0.5",
+    version="2.1.0",
     description="Singer.io tap for extracting data from the Yotpo API",
     author="Stitch",
     url="https://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ setup(
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_yotpo"],
     install_requires=[
-        "singer-python==5.13.2",
-        "requests==2.32.4",
+        "singer-python==6.8.0",
+        "requests==2.34.0",
     ],
     extras_require={
         "dev": [

--- a/tap_yotpo/streams/__init__.py
+++ b/tap_yotpo/streams/__init__.py
@@ -12,11 +12,11 @@ from .unsubscribers import Unsubscribers
 STREAMS = {
     Collections.tap_stream_id: Collections,
     Emails.tap_stream_id: Emails,
-    OrderFulfillments.tap_stream_id: OrderFulfillments,
     Orders.tap_stream_id: Orders,
+    OrderFulfillments.tap_stream_id: OrderFulfillments,
+    Products.tap_stream_id: Products,
     ProductReviews.tap_stream_id: ProductReviews,
     ProductVariants.tap_stream_id: ProductVariants,
-    Products.tap_stream_id: Products,
     Reviews.tap_stream_id: Reviews,
     Unsubscribers.tap_stream_id: Unsubscribers,
 }

--- a/tap_yotpo/streams/abstracts.py
+++ b/tap_yotpo/streams/abstracts.py
@@ -27,6 +27,8 @@ class BaseStream(ABC):
      - `sync` and `get_records` method for performing sync
     """
 
+    parent = ""
+
     @property
     @abstractmethod
     def stream(self) -> str:
@@ -132,7 +134,6 @@ class IncrementalStream(BaseStream):
     replication_method = "INCREMENTAL"
     forced_replication_method = "INCREMENTAL"
     config_start_key = None
-    parent = ""
 
     def get_bookmark(self, state: dict, key: Any = None) -> int:
         """A wrapper for singer.get_bookmark to deal with compatibility for
@@ -177,7 +178,6 @@ class FullTableStream(BaseStream):
     forced_replication_method = "FULL_TABLE"
     valid_replication_keys = None
     replication_key = None
-    parent = ""
 
     def sync(self, state: Dict, schema: Dict, stream_metadata: Dict, transformer: Transformer) -> Dict:
         """Abstract implementation for `type: Fulltable` stream."""

--- a/tap_yotpo/streams/abstracts.py
+++ b/tap_yotpo/streams/abstracts.py
@@ -118,6 +118,10 @@ class BaseStream(ABC):
         if cls.valid_replication_keys is not None:
             for key in cls.valid_replication_keys:
                 stream_metadata = write(stream_metadata, ("properties", key), "inclusion", "automatic")
+
+        if hasattr(cls, "parent") and cls.parent:
+            stream_metadata = write(stream_metadata, (), 'parent-tap-stream-id', cls.parent)
+
         stream_metadata = to_list(stream_metadata)
         return stream_metadata
 

--- a/tap_yotpo/streams/abstracts.py
+++ b/tap_yotpo/streams/abstracts.py
@@ -132,6 +132,7 @@ class IncrementalStream(BaseStream):
     replication_method = "INCREMENTAL"
     forced_replication_method = "INCREMENTAL"
     config_start_key = None
+    parent = ""
 
     def get_bookmark(self, state: dict, key: Any = None) -> int:
         """A wrapper for singer.get_bookmark to deal with compatibility for
@@ -176,6 +177,7 @@ class FullTableStream(BaseStream):
     forced_replication_method = "FULL_TABLE"
     valid_replication_keys = None
     replication_key = None
+    parent = ""
 
     def sync(self, state: Dict, schema: Dict, stream_metadata: Dict, transformer: Transformer) -> Dict:
         """Abstract implementation for `type: Fulltable` stream."""

--- a/tap_yotpo/streams/order_fulfillments.py
+++ b/tap_yotpo/streams/order_fulfillments.py
@@ -33,6 +33,7 @@ class OrderFulfillments(IncrementalStream, UrlEndpointMixin, PageSizeMixin):
     # points to the attribute of the config that marks the first-start-date for the stream
     config_start_key = "start_date"
     url_endpoint = "https://api.yotpo.com/core/v3/stores/APP_KEY/orders/ORDER_ID/fulfillments"
+    parent = "orders"
 
     def __init__(self, client=None) -> None:
         super().__init__(client)

--- a/tap_yotpo/streams/product_reviews.py
+++ b/tap_yotpo/streams/product_reviews.py
@@ -35,6 +35,7 @@ class ProductReviews(IncrementalStream, UrlEndpointMixin, PageSizeMixin):
     config_start_key = "start_date"
     url_endpoint = "https://api-cdn.yotpo.com/v1/widget/APP_KEY/products/PRODUCT_ID/reviews.json"
     default_page_size = 150
+    parent = "products"
 
     def __init__(self, client=None) -> None:
         super().__init__(client)

--- a/tap_yotpo/streams/product_variants.py
+++ b/tap_yotpo/streams/product_variants.py
@@ -33,6 +33,7 @@ class ProductVariants(IncrementalStream, UrlEndpointMixin, PageSizeMixin):
     # points to the attribute of the config that marks the first-start-date for the stream
     config_start_key = "start_date"
     url_endpoint = "https://api.yotpo.com/core/v3/stores/APP_KEY/products/PRODUCT_ID/variants"
+    parent = "products"
 
     def __init__(self, client=None) -> None:
         super().__init__(client)

--- a/tests/unittests/test_parent_metadata.py
+++ b/tests/unittests/test_parent_metadata.py
@@ -1,0 +1,125 @@
+import unittest
+from unittest.mock import Mock, patch
+import os
+import json
+
+from tap_yotpo.streams.order_fulfillments import OrderFulfillments
+from tap_yotpo.streams.product_reviews import ProductReviews
+from tap_yotpo.streams.product_variants import ProductVariants
+from tap_yotpo.streams.products import Products
+from tap_yotpo.streams.orders import Orders
+from tap_yotpo.client import Client
+
+
+class TestParentMetadata(unittest.TestCase):
+    """Test cases for parent-tap-stream-id metadata functionality."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Create a mock client with config
+        self.mock_client = Mock()
+        self.mock_client.config = {"api_key": "test_key", "api_secret": "test_secret"}
+
+    def _get_stream_metadata(self, metadata):
+        """Helper to find stream-level metadata (breadcrumb = ())."""
+        for entry in metadata:
+            if entry['breadcrumb'] == ():
+                return entry
+        return None
+
+    def test_parent_metadata_order_fulfillments(self):
+        """Test that order_fulfillments stream has parent metadata set to 'orders'."""
+        # Test the get_metadata method directly on the class
+        # Load a simple schema for testing
+        simple_schema = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "updated_at": {"type": "string", "format": "date-time"}
+            }
+        }
+        
+        metadata = OrderFulfillments.get_metadata(simple_schema)
+        stream_metadata = self._get_stream_metadata(metadata)
+        
+        # Assert that parent-tap-stream-id is set correctly
+        self.assertIsNotNone(stream_metadata)
+        self.assertEqual(stream_metadata['metadata']['parent-tap-stream-id'], 'orders')
+
+    def test_parent_metadata_product_reviews(self):
+        """Test that product_reviews stream has parent metadata set to 'products'."""
+        # Test the get_metadata method directly on the class
+        simple_schema = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "created_at": {"type": "string", "format": "date-time"}
+            }
+        }
+        
+        metadata = ProductReviews.get_metadata(simple_schema)
+        stream_metadata = self._get_stream_metadata(metadata)
+        
+        # Assert that parent-tap-stream-id is set correctly
+        self.assertIsNotNone(stream_metadata)
+        self.assertEqual(stream_metadata['metadata']['parent-tap-stream-id'], 'products')
+
+    def test_parent_metadata_product_variants(self):
+        """Test that product_variants stream has parent metadata set to 'products'."""
+        # Test the get_metadata method directly on the class
+        simple_schema = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "updated_at": {"type": "string", "format": "date-time"}
+            }
+        }
+        
+        metadata = ProductVariants.get_metadata(simple_schema)
+        stream_metadata = self._get_stream_metadata(metadata)
+        
+        # Assert that parent-tap-stream-id is set correctly
+        self.assertIsNotNone(stream_metadata)
+        self.assertEqual(stream_metadata['metadata']['parent-tap-stream-id'], 'products')
+
+    def test_no_parent_metadata_for_parent_streams(self):
+        """Test that parent streams (products, orders) do not have parent metadata."""
+        # Test Products stream (parent stream)
+        simple_schema = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"}
+            }
+        }
+        
+        products_metadata = Products.get_metadata(simple_schema)
+        products_stream_metadata = self._get_stream_metadata(products_metadata)
+        
+        # Assert that parent-tap-stream-id is NOT set for parent streams
+        self.assertIsNotNone(products_stream_metadata)
+        self.assertNotIn('parent-tap-stream-id', products_stream_metadata['metadata'])
+        
+        # Test Orders stream (parent stream)
+        orders_metadata = Orders.get_metadata(simple_schema)
+        orders_stream_metadata = self._get_stream_metadata(orders_metadata)
+        
+        # Assert that parent-tap-stream-id is NOT set for parent streams
+        self.assertIsNotNone(orders_stream_metadata)
+        self.assertNotIn('parent-tap-stream-id', orders_stream_metadata['metadata'])
+
+    def test_parent_attribute_exists_on_child_streams(self):
+        """Test that the parent class attribute exists on child streams."""
+        self.assertTrue(hasattr(OrderFulfillments, 'parent'))
+        self.assertEqual(OrderFulfillments.parent, 'orders')
+        
+        self.assertTrue(hasattr(ProductReviews, 'parent'))
+        self.assertEqual(ProductReviews.parent, 'products')
+        
+        self.assertTrue(hasattr(ProductVariants, 'parent'))
+        self.assertEqual(ProductVariants.parent, 'products')
+
+    def test_parent_attribute_not_exists_on_parent_streams(self):
+        """Test that the parent class attribute does not exist on parent streams."""
+        # Products and Orders should not have parent attribute
+        self.assertFalse(hasattr(Products, 'parent'))
+        self.assertFalse(hasattr(Orders, 'parent'))

--- a/tests/unittests/test_parent_metadata.py
+++ b/tests/unittests/test_parent_metadata.py
@@ -119,7 +119,10 @@ class TestParentMetadata(unittest.TestCase):
         self.assertEqual(ProductVariants.parent, 'products')
 
     def test_parent_attribute_not_exists_on_parent_streams(self):
-        """Test that the parent class attribute does not exist on parent streams."""
-        # Products and Orders should not have parent attribute
-        self.assertFalse(hasattr(Products, 'parent'))
-        self.assertFalse(hasattr(Orders, 'parent'))
+        """Test that the parent class attribute is None or empty string on parent streams."""
+        # Products and Orders should have parent attribute as None or empty string
+        self.assertTrue(hasattr(Products, 'parent'))
+        self.assertTrue(hasattr(Orders, 'parent'))
+        # Parent streams should have None or empty parent value
+        self.assertIn(Products.parent, [None, ""])
+        self.assertIn(Orders.parent, [None, ""])


### PR DESCRIPTION
# Description of change
Ticket: https://qlik-dev.atlassian.net/browse/SAC-28902
* Introduces the `parent_tap_stream_id` field in the stream metadata for proper lineage tracking.
* Adds corresponding test cases to validate the new field.

# Manual QA steps
 - [ ]  Discovery: Creds unavailable
 - [ ]  Sync: Creds unavailable
 - [x]  Unit Tests: Passes
 - [ ]  Integration test: Fails
 
# Rollback steps
 - revert this branch
