### PR TITLE
PR 2 - [SAC-31191] - Unauthorized streams exclusion from catalog during discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@ celerybeat-schedule
 venv/
 ENV/
 
+# Temporary
+tmp/
+
 # Spyder project settings
 .spyderproject
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.1.0
   * Add parent-tap-stream-id metadata for child streams [#65](https://github.com/singer-io/tap-yotpo/pull/65)
   * Bump dependency versions: `singer-python` to `6.8.0`
-  * Streams the credentials cannot access (403) are now excluded from the catalog during discovery [#68](https://github.com/singer-io/tap-yotpo/pull/68)
+  * Streams that cannot be accessed due to insufficient permissions (403) are now excluded from the catalog during discovery instead of raising an error [#68](https://github.com/singer-io/tap-yotpo/pull/68)
 
 # 2.0.6
   * Bump requests to 2.33.0 for security updates [#67](https://github.com/singer-io/tap-yotpo/pull/67)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
 # Changelog
 
-## 2.2.0
-  * Streams the credentials cannot access (403) are now excluded from the catalog during discovery [#68](https://github.com/singer-io/tap-yotpo/pull/68)
-
 ## 2.1.0
   * Add parent-tap-stream-id metadata for child streams [#65](https://github.com/singer-io/tap-yotpo/pull/65)
   * Bump dependency versions: `singer-python` to `6.8.0`
+  * Streams the credentials cannot access (403) are now excluded from the catalog during discovery [#68](https://github.com/singer-io/tap-yotpo/pull/68)
 
 # 2.0.6
   * Bump requests to 2.33.0 for security updates [#67](https://github.com/singer-io/tap-yotpo/pull/67)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.0
+  * Streams the credentials cannot access (403) are now excluded from the catalog during discovery [#68](https://github.com/singer-io/tap-yotpo/pull/68)
+
 ## 2.1.0
   * Add parent-tap-stream-id metadata for child streams [#65](https://github.com/singer-io/tap-yotpo/pull/65)
   * Bump dependency versions: `singer-python` to `6.8.0`

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="tap-yotpo",
-    version="2.1.0",
+    version="2.2.0",
     description="Singer.io tap for extracting data from the Yotpo API",
     author="Stitch",
     url="https://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="tap-yotpo",
-    version="2.2.0",
+    version="2.1.0",
     description="Singer.io tap for extracting data from the Yotpo API",
     author="Stitch",
     url="https://singer.io",

--- a/tap_yotpo/__init__.py
+++ b/tap_yotpo/__init__.py
@@ -18,14 +18,14 @@ def main():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
     client = Client(args.config)
     if args.discover:
-        discover(args.config).dump()
+        discover(client).dump()
     else:
         with Counter("total_requests", log_interval=sys.maxsize) as req_counter, Timer(
             "total_extraction_time", None
         ) as req_timer:
             client.req_counter = req_counter
             client.req_timer = req_timer
-            sync(client, args.catalog or discover(args.config), args.state)
+            sync(client, args.catalog or discover(client), args.state)
 
 
 if __name__ == "__main__":

--- a/tap_yotpo/discover.py
+++ b/tap_yotpo/discover.py
@@ -1,30 +1,89 @@
 """tap-yotpo discover module."""
 import json
-from typing import Dict
 
+from singer import get_logger
 from singer.catalog import Catalog
 
-from tap_yotpo.client import Client
-from tap_yotpo.helpers import ApiSpec, get_abs_path
+from tap_yotpo.exceptions import Http403RequestError
+from tap_yotpo.helpers import get_abs_path
 from tap_yotpo.streams import STREAMS
 
+LOGGER = get_logger()
 
-def discover(config: Dict = None):
+
+def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
+    """Checks accessibility of each stream, removing inaccessible ones.
+
+    Streams that return a 403 Forbidden response are excluded from the catalog.
+    After removing inaccessible parent streams, child streams whose parents were
+    excluded are also pruned. Raises if no parent streams remain accessible.
+    """
+    inaccessible_streams = []
+    for stream_name, stream_class in list(schemas.items()):
+        stream_instance = stream_class(client)
+        if not stream_instance.check_access():
+            LOGGER.warning(
+                "Stream '%s' is not accessible (403 Forbidden). Excluding from catalog.",
+                stream_name,
+            )
+            inaccessible_streams.append(stream_name)
+
+    for stream_name in inaccessible_streams:
+        del schemas[stream_name]
+        del field_metadata[stream_name]
+
+    _prune_inaccessible_children(schemas, field_metadata)
+
+    accessible_parents = [s for s in schemas.values() if not getattr(s, "parent", "")]
+    if not accessible_parents:
+        raise Exception("All parent streams are inaccessible. Cannot produce a usable catalog.")
+
+
+def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
+    """Removes child streams whose parents have been excluded from schemas."""
+    to_remove = []
+    for stream_name, stream_class in schemas.items():
+        parent = getattr(stream_class, "parent", "")
+        if parent and parent not in schemas:
+            LOGGER.warning(
+                "Stream '%s' is a child of '%s' which is excluded. Excluding child stream too.",
+                stream_name,
+                parent,
+            )
+            to_remove.append(stream_name)
+
+    for stream_name in to_remove:
+        del schemas[stream_name]
+        del field_metadata[stream_name]
+
+    # Recurse to handle multi-level parent-child relationships
+    if to_remove:
+        _prune_inaccessible_children(schemas, field_metadata)
+
+
+def discover(client) -> Catalog:
     """Performs Discovery for tap-yotpo."""
-    if config:
-        client = Client(config)
-        client.authenticate({}, {}, ApiSpec.API_V3)
-    streams = []
-    for stream_name, stream in STREAMS.items():
+    schemas = {}
+    field_metadata = {}
+
+    for stream_name, stream_class in STREAMS.items():
         schema_path = get_abs_path(f"schemas/{stream_name}.json")
         with open(schema_path, encoding="utf-8") as schema_file:
             schema = json.load(schema_file)
+        schemas[stream_name] = stream_class
+        field_metadata[stream_name] = (schema, stream_class.get_metadata(schema))
+
+    _apply_access_checks(client, schemas, field_metadata)
+
+    streams = []
+    for stream_name, stream_class in schemas.items():
+        schema, metadata = field_metadata[stream_name]
         streams.append(
             {
                 "stream": stream_name,
-                "tap_stream_id": stream.tap_stream_id,
+                "tap_stream_id": stream_class.tap_stream_id,
                 "schema": schema,
-                "metadata": stream.get_metadata(schema),
+                "metadata": metadata,
             }
         )
     return Catalog.from_dict({"streams": streams})

--- a/tap_yotpo/discover.py
+++ b/tap_yotpo/discover.py
@@ -4,7 +4,6 @@ import json
 from singer import get_logger
 from singer.catalog import Catalog
 
-from tap_yotpo.exceptions import Http403RequestError
 from tap_yotpo.helpers import get_abs_path
 from tap_yotpo.streams import STREAMS
 
@@ -36,7 +35,7 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
 
     accessible_parents = [s for s in schemas.values() if not getattr(s, "parent", "")]
     if not accessible_parents:
-        raise Exception("All parent streams are inaccessible. Cannot produce a usable catalog.")
+        raise RuntimeError("All parent streams are inaccessible. Cannot produce a usable catalog.")
 
 
 def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:

--- a/tap_yotpo/streams/abstracts.py
+++ b/tap_yotpo/streams/abstracts.py
@@ -13,6 +13,8 @@ from singer import (
 from singer.metadata import get_standard_metadata, to_list, to_map, write
 from singer.utils import strftime, strptime_to_utc
 
+from ..exceptions import Http403RequestError
+
 LOGGER = get_logger()
 
 
@@ -104,6 +106,21 @@ class BaseStream(ABC):
 
     def __init__(self, client=None) -> None:
         self.client = client
+
+    def check_access(self) -> bool:
+        """Checks if the stream is accessible via the API.
+
+        Child streams always return True since their accessibility is
+        determined by their parent stream. For parent streams, a test
+        API call is made; a 403 response means the stream is excluded.
+        """
+        if getattr(self, "parent", ""):
+            return True
+        try:
+            self.client.get(self.get_url_endpoint(), {}, {}, self.api_auth_version)
+            return True
+        except Http403RequestError:
+            return False
 
     @classmethod
     def get_metadata(cls, schema) -> Dict[str, str]:

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,0 +1,301 @@
+"""Unit tests for tap-yotpo discovery module."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tap_yotpo.discover import _apply_access_checks, _prune_inaccessible_children, discover
+from tap_yotpo.streams import STREAMS
+from tap_yotpo.streams.abstracts import BaseStream
+
+PARENT_STREAMS = [name for name, cls in STREAMS.items() if not getattr(cls, "parent", "")]
+CHILD_STREAMS = [name for name, cls in STREAMS.items() if getattr(cls, "parent", "")]
+SIMPLE_SCHEMA = {"type": "object", "properties": {"id": {"type": "integer"}}}
+
+
+def _build_test_data():
+    """Builds schemas and field_metadata dicts for all streams."""
+    schemas = dict(STREAMS)
+    field_metadata = {
+        name: (SIMPLE_SCHEMA, cls.get_metadata(SIMPLE_SCHEMA)) for name, cls in STREAMS.items()
+    }
+    return schemas, field_metadata
+
+
+class TestPruneInaccessibleChildren(unittest.TestCase):
+    """Tests for _prune_inaccessible_children function."""
+
+    def test_child_removed_when_parent_absent(self):
+        """Child stream is removed when its parent is not in the schemas dict."""
+        schemas = {"product_reviews": STREAMS["product_reviews"]}
+        field_metadata = {"product_reviews": (SIMPLE_SCHEMA, [])}
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertNotIn("product_reviews", schemas)
+        self.assertNotIn("product_reviews", field_metadata)
+
+    def test_child_kept_when_parent_present(self):
+        """Child stream is kept when its parent is also in the schemas dict."""
+        schemas = {
+            "products": STREAMS["products"],
+            "product_reviews": STREAMS["product_reviews"],
+        }
+        field_metadata = {
+            "products": (SIMPLE_SCHEMA, []),
+            "product_reviews": (SIMPLE_SCHEMA, []),
+        }
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertIn("product_reviews", schemas)
+        self.assertIn("products", schemas)
+
+    def test_parent_streams_never_removed(self):
+        """Streams without a parent are not removed by pruning."""
+        schemas = {"reviews": STREAMS["reviews"], "collections": STREAMS["collections"]}
+        field_metadata = {"reviews": (SIMPLE_SCHEMA, []), "collections": (SIMPLE_SCHEMA, [])}
+        original_count = len(schemas)
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertEqual(len(schemas), original_count)
+
+    def test_both_product_children_removed_when_products_absent(self):
+        """Both product_reviews and product_variants are removed when products is absent."""
+        schemas = {
+            "product_reviews": STREAMS["product_reviews"],
+            "product_variants": STREAMS["product_variants"],
+        }
+        field_metadata = {
+            "product_reviews": (SIMPLE_SCHEMA, []),
+            "product_variants": (SIMPLE_SCHEMA, []),
+        }
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertNotIn("product_reviews", schemas)
+        self.assertNotIn("product_variants", schemas)
+
+    def test_order_fulfillments_removed_when_orders_absent(self):
+        """order_fulfillments is removed when orders is not in schemas."""
+        schemas = {"order_fulfillments": STREAMS["order_fulfillments"]}
+        field_metadata = {"order_fulfillments": (SIMPLE_SCHEMA, [])}
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertNotIn("order_fulfillments", schemas)
+
+
+class TestApplyAccessChecks(unittest.TestCase):
+    """Tests for _apply_access_checks function."""
+
+    def setUp(self):
+        self.mock_client = MagicMock()
+        self.mock_client.config = {"api_key": "test_key", "api_secret": "test_secret"}
+
+    def test_all_accessible_keeps_all_streams(self):
+        """When all streams are accessible, all remain in the catalog."""
+        schemas, field_metadata = _build_test_data()
+
+        def always_accessible(self_):
+            return True
+
+        with patch.object(BaseStream, "check_access", new=always_accessible):
+            _apply_access_checks(self.mock_client, schemas, field_metadata)
+
+        self.assertEqual(set(schemas.keys()), set(STREAMS.keys()))
+
+    def test_inaccessible_products_excludes_its_children(self):
+        """When products is inaccessible, product_reviews and product_variants are also excluded."""
+        schemas, field_metadata = _build_test_data()
+
+        def check_access_fn(self_):
+            if getattr(self_, "parent", ""):
+                return True
+            return self_.tap_stream_id != "products"
+
+        with patch.object(BaseStream, "check_access", new=check_access_fn):
+            _apply_access_checks(self.mock_client, schemas, field_metadata)
+
+        self.assertNotIn("products", schemas)
+        self.assertNotIn("product_reviews", schemas)
+        self.assertNotIn("product_variants", schemas)
+        self.assertIn("orders", schemas)
+        self.assertIn("order_fulfillments", schemas)
+
+    def test_inaccessible_orders_excludes_order_fulfillments(self):
+        """When orders is inaccessible, order_fulfillments is also excluded."""
+        schemas, field_metadata = _build_test_data()
+
+        def check_access_fn(self_):
+            if getattr(self_, "parent", ""):
+                return True
+            return self_.tap_stream_id != "orders"
+
+        with patch.object(BaseStream, "check_access", new=check_access_fn):
+            _apply_access_checks(self.mock_client, schemas, field_metadata)
+
+        self.assertNotIn("orders", schemas)
+        self.assertNotIn("order_fulfillments", schemas)
+        self.assertIn("products", schemas)
+
+    def test_all_parent_streams_inaccessible_raises_exception(self):
+        """When all parent streams are inaccessible, an exception is raised."""
+        schemas, field_metadata = _build_test_data()
+
+        def only_children_accessible(self_):
+            return bool(getattr(self_, "parent", ""))
+
+        with patch.object(BaseStream, "check_access", new=only_children_accessible):
+            with self.assertRaises(Exception):
+                _apply_access_checks(self.mock_client, schemas, field_metadata)
+
+    def test_partial_access_warning_logged(self):
+        """A warning is logged when a stream is excluded due to inaccessibility."""
+        schemas, field_metadata = _build_test_data()
+
+        def check_access_fn(self_):
+            if getattr(self_, "parent", ""):
+                return True
+            return self_.tap_stream_id != "reviews"
+
+        with patch.object(BaseStream, "check_access", new=check_access_fn), \
+                patch("tap_yotpo.discover.LOGGER") as mock_logger:
+            _apply_access_checks(self.mock_client, schemas, field_metadata)
+
+        warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
+        self.assertTrue(any("reviews" in c for c in warning_calls))
+
+
+class TestCheckAccess(unittest.TestCase):
+    """Tests for BaseStream.check_access() method."""
+
+    def setUp(self):
+        self.mock_client = MagicMock()
+        self.mock_client.config = {"api_key": "test_key", "api_secret": "test_secret"}
+
+    def test_child_stream_always_accessible(self):
+        """Child streams always return True from check_access regardless of API response."""
+        from tap_yotpo.streams.product_reviews import ProductReviews
+
+        stream = ProductReviews(self.mock_client)
+        self.assertTrue(stream.check_access())
+        self.mock_client.get.assert_not_called()
+
+    def test_child_stream_product_variants_always_accessible(self):
+        """product_variants (a child stream) always returns True."""
+        from tap_yotpo.streams.product_variants import ProductVariants
+
+        stream = ProductVariants(self.mock_client)
+        self.assertTrue(stream.check_access())
+
+    def test_parent_stream_accessible_when_api_returns_200(self):
+        """Parent stream returns True when API call succeeds."""
+        from tap_yotpo.streams.reviews import Reviews
+
+        self.mock_client.get.return_value = {}
+        stream = Reviews(self.mock_client)
+        self.assertTrue(stream.check_access())
+
+    def test_parent_stream_inaccessible_on_403(self):
+        """Parent stream returns False when API raises Http403RequestError."""
+        from tap_yotpo.exceptions import Http403RequestError
+        from tap_yotpo.streams.reviews import Reviews
+
+        self.mock_client.get.side_effect = Http403RequestError()
+        stream = Reviews(self.mock_client)
+        self.assertFalse(stream.check_access())
+
+
+class TestDiscover(unittest.TestCase):
+    """Tests for the discover() function."""
+
+    def setUp(self):
+        self.mock_client = MagicMock()
+        self.mock_client.config = {"api_key": "test_key", "api_secret": "test_secret"}
+
+    def test_returns_catalog_with_all_streams_when_all_accessible(self):
+        """discover() returns a Catalog with all streams when all are accessible."""
+
+        def always_accessible(self_):
+            return True
+
+        with patch.object(BaseStream, "check_access", new=always_accessible):
+            catalog = discover(self.mock_client)
+
+        stream_ids = {s.tap_stream_id for s in catalog.streams}
+        self.assertEqual(stream_ids, set(STREAMS.keys()))
+
+    def test_excludes_inaccessible_streams_from_catalog(self):
+        """discover() excludes streams that fail the access check."""
+
+        def check_access_fn(self_):
+            if getattr(self_, "parent", ""):
+                return True
+            return self_.tap_stream_id != "reviews"
+
+        with patch.object(BaseStream, "check_access", new=check_access_fn):
+            catalog = discover(self.mock_client)
+
+        stream_ids = {s.tap_stream_id for s in catalog.streams}
+        self.assertNotIn("reviews", stream_ids)
+        self.assertIn("products", stream_ids)
+
+    def test_catalog_streams_have_schema_and_metadata(self):
+        """Each stream entry in the catalog has a schema and metadata."""
+
+        def always_accessible(self_):
+            return True
+
+        with patch.object(BaseStream, "check_access", new=always_accessible):
+            catalog = discover(self.mock_client)
+
+        for stream_entry in catalog.streams:
+            self.assertIsNotNone(stream_entry.schema)
+            self.assertIsNotNone(stream_entry.metadata)
+            self.assertGreater(len(stream_entry.metadata), 0)
+
+    def test_catalog_stream_primary_keys_marked_automatic(self):
+        """Primary key fields in stream metadata have inclusion set to 'automatic'."""
+
+        def always_accessible(self_):
+            return True
+
+        with patch.object(BaseStream, "check_access", new=always_accessible):
+            catalog = discover(self.mock_client)
+
+        for stream_entry in catalog.streams:
+            stream_class = STREAMS[stream_entry.tap_stream_id]
+            metadata_map = {tuple(e["breadcrumb"]): e["metadata"] for e in stream_entry.metadata}
+            for key in stream_class.key_properties:
+                key_meta = metadata_map.get(("properties", key), {})
+                self.assertEqual(
+                    key_meta.get("inclusion"),
+                    "automatic",
+                    f"Expected 'automatic' for key '{key}' in stream '{stream_entry.tap_stream_id}'",
+                )
+
+    def test_catalog_stream_replication_keys_marked_automatic(self):
+        """Replication key fields for incremental streams are marked as automatic."""
+
+        def always_accessible(self_):
+            return True
+
+        with patch.object(BaseStream, "check_access", new=always_accessible):
+            catalog = discover(self.mock_client)
+
+        for stream_entry in catalog.streams:
+            stream_class = STREAMS[stream_entry.tap_stream_id]
+            if not stream_class.valid_replication_keys:
+                continue
+            metadata_map = {tuple(e["breadcrumb"]): e["metadata"] for e in stream_entry.metadata}
+            for key in stream_class.valid_replication_keys:
+                key_meta = metadata_map.get(("properties", key), {})
+                self.assertEqual(
+                    key_meta.get("inclusion"),
+                    "automatic",
+                    f"Expected 'automatic' for replication key '{key}' in stream '{stream_entry.tap_stream_id}'",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -146,7 +146,7 @@ class TestApplyAccessChecks(unittest.TestCase):
             return bool(getattr(self_, "parent", ""))
 
         with patch.object(BaseStream, "check_access", new=only_children_accessible):
-            with self.assertRaises(Exception):
+            with self.assertRaises(RuntimeError):
                 _apply_access_checks(self.mock_client, schemas, field_metadata)
 
     def test_partial_access_warning_logged(self):

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -295,7 +295,3 @@ class TestDiscover(unittest.TestCase):
                     "automatic",
                     f"Expected 'automatic' for replication key '{key}' in stream '{stream_entry.tap_stream_id}'",
                 )
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
# Description of change
Ticket: https://qlik-dev.atlassian.net/browse/SAC-31191
- Exclude unauthorized streams from catalog during discovery  


# Manual QA steps
 - [ ]  Discovery: Creds unavailable
 - [ ]  Sync: Creds unavailable
 - [x]  Unit Tests: Passes
 - [ ]  Integration test: Fails
 
# Rollback steps
 - revert this branch